### PR TITLE
Remove classmap and vendor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,6 @@
         "phpunit/phpunit": "^4.8 || ^5.7"
     },
     "autoload": {
-        "classmap": [
-            "src/"
-        ],
         "psr-4": {
             "PhpIntegrator\\": "src/"
         }
@@ -34,7 +31,6 @@
         "test" : "vendor/bin/phpunit"
     },
     "config" : {
-        "vendor-dir" : "vendor",
         "platform": {
             "php": "5.6.0"
         }


### PR DESCRIPTION
We don't need to autoload the classes with both PSR-4 and classmap. We should stick to only PSR-4. Also, vendor is the default name for the `vendor-dir` configuration.